### PR TITLE
Refactor success state and container rerenders

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -43,7 +43,7 @@ function App() {
       }
 
       try {
-        let res = await axios.get(`${backendUrl}/FAQ`);
+        let res = await axios.get(`${backendUrl}/questions`);
         dispatch({ type: 'UPDATE_QUESTIONS_DATA', newQuestionsData: res.data });
       } catch (err) {
         console.log(err);

--- a/src/components/AttachmentField.jsx
+++ b/src/components/AttachmentField.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { useDropzone } from 'react-dropzone';
 import './AttachmentField.css';
 import { blobsToUniqueFiles } from '../utils/files/general';
 import { rotatedImageBlobsWithExif } from '../utils/files/images';
 
 function AttachmentField(props) {
-  const { input, files, setFiles, success, setSuccess } = props;
+  const { input, files, setFiles, /*success, setSuccess*/ } = props;
+  const successfulSubmit = useSelector((state) => state.adminDashReducer.successfulSubmit);
   const { getRootProps, getInputProps } = useDropzone({
     accept: 'image/*',
     onDrop: async (acceptedFiles) => {
@@ -16,7 +18,7 @@ function AttachmentField(props) {
       setFiles(rotatedUniqueFiles.map(file => Object.assign(file, {
         preview: URL.createObjectURL(file)
       })).concat(files));
-      setSuccess(false);
+      // setSuccess(false);
     }
   });
   
@@ -39,7 +41,8 @@ function AttachmentField(props) {
       </div>
       <aside className="thumbs-container">
         {
-          success ?
+          // success ?
+          successfulSubmit ?
           <div>
             {'File Uploaded!'}
           </div> :

--- a/src/components/AttachmentField.jsx
+++ b/src/components/AttachmentField.jsx
@@ -1,13 +1,14 @@
-import React, { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { useDropzone } from 'react-dropzone';
 import './AttachmentField.css';
 import { blobsToUniqueFiles } from '../utils/files/general';
 import { rotatedImageBlobsWithExif } from '../utils/files/images';
 
 function AttachmentField(props) {
-  const { input, files, setFiles, /*success, setSuccess*/ } = props;
+  const { input, files, setFiles } = props;
   const successfulSubmit = useSelector((state) => state.adminDashReducer.successfulSubmit);
+  const dispatch = useDispatch();
   const { getRootProps, getInputProps } = useDropzone({
     accept: 'image/*',
     onDrop: async (acceptedFiles) => {
@@ -18,7 +19,7 @@ function AttachmentField(props) {
       setFiles(rotatedUniqueFiles.map(file => Object.assign(file, {
         preview: URL.createObjectURL(file)
       })).concat(files));
-      // setSuccess(false);
+      dispatch({ type: 'NO_SUCCESSFUL_SUBMIT' });
     }
   });
   
@@ -41,7 +42,6 @@ function AttachmentField(props) {
       </div>
       <aside className="thumbs-container">
         {
-          // success ?
           successfulSubmit ?
           <div>
             {'File Uploaded!'}

--- a/src/components/BtnDeleteDoc.jsx
+++ b/src/components/BtnDeleteDoc.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import axios from 'axios';
 import _ from 'lodash';
 
@@ -12,10 +12,7 @@ function BtnDeleteDoc(props) {
   async function handleDelete() {
     try {
       await axios.delete(`${backendUrl}/${collection}/${id}`);
-      (async () => {
-        let res = await axios.get(`${backendUrl}/${collection}`);
-        dispatch({ type: `UPDATE_${collection.toUpperCase()}_DATA`, [`new${_.upperFirst(collection)}Data`]: res.data })
-      })();
+      dispatch({ type: 'SUCCESSFUL_SUBMIT' });
     } catch (err) {
       console.log(err);
     }

--- a/src/components/BtnDeleteDoc.jsx
+++ b/src/components/BtnDeleteDoc.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import axios from 'axios';
 import _ from 'lodash';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL;
 
 function BtnDeleteDoc(props) {
-  const { collection, id } = props;
+  const { collection, id, category } = props;
   const dispatch = useDispatch();
 
   async function handleDelete() {
@@ -14,6 +14,9 @@ function BtnDeleteDoc(props) {
       await axios.delete(`${backendUrl}/${collection}/${id}`);
       let res = await axios.get(`${backendUrl}/${collection}`);
       dispatch({ type: `UPDATE_${collection.toUpperCase()}_DATA`, [`new${_.upperFirst(collection)}Data`]: res.data });
+      if (category) {
+        dispatch({ type: `${category.toUpperCase()}_PORTFOLIO_DATA` });
+      }
     } catch (err) {
       console.log(err);
     }

--- a/src/components/BtnDeleteDoc.jsx
+++ b/src/components/BtnDeleteDoc.jsx
@@ -12,7 +12,8 @@ function BtnDeleteDoc(props) {
   async function handleDelete() {
     try {
       await axios.delete(`${backendUrl}/${collection}/${id}`);
-      dispatch({ type: 'SUCCESSFUL_SUBMIT' });
+      let res = await axios.get(`${backendUrl}/${collection}`);
+      dispatch({ type: `UPDATE_${collection.toUpperCase()}_DATA`, [`new${_.upperFirst(collection)}Data`]: res.data });
     } catch (err) {
       console.log(err);
     }

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,4 +1,4 @@
-import React,{useState,useEffect} from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import logoplaceholder from '../../media/logo-placeholder.png';

--- a/src/components/PortfolioContainer.jsx
+++ b/src/components/PortfolioContainer.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import Work from './Work';
-import { masonryOptions } from "../components/Portfolio/Exports";
+import { masonryOptions } from '../components/Portfolio/Exports';
 import Masonry from 'react-masonry-component';
 import FilterButtons from '../components/Portfolio/FilterButtons'
 
 function PortfolioContainer() {
   const filteredPortfolioData = useSelector((state) => state.portfolioReducer.filteredPortfolioData);
-  
+
   return (
     <section className="PortfolioContainer">
       <FilterButtons />

--- a/src/components/PortfolioContainer.jsx
+++ b/src/components/PortfolioContainer.jsx
@@ -21,13 +21,14 @@ function PortfolioContainer() {
       {
         filteredPortfolioData ?
         filteredPortfolioData.map((service, index) => {
-          const { _id, imageUrl } = service;
+          const { _id, imageUrl, category } = service;
 
           return (
             <Work
               key={index}
               id={_id}
               imageUrl={imageUrl}
+              category={category}
             />
           )
         }) :

--- a/src/components/Question.jsx
+++ b/src/components/Question.jsx
@@ -6,7 +6,7 @@ import './Question.css';
 function Question(props) {
   const onAdminDash = useSelector((state) => state.adminDashReducer.onAdminDash);
   const { id, question, answer } = props;
-  const collection = 'FAQ';
+  const collection = 'questions';
 
   return (
     <article className="Question">

--- a/src/components/QuestionForm/QuestionForm.jsx
+++ b/src/components/QuestionForm/QuestionForm.jsx
@@ -1,9 +1,6 @@
-import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import { useDispatch } from 'react-redux';
 import { Field, reduxForm } from 'redux-form';
-import axios from 'axios';
-
-const backendUrl = process.env.REACT_APP_BACKEND_URL;
 
 function validate(values)
 {
@@ -35,15 +32,9 @@ function QuestionForm(props) {
   const { handleSubmit, pristine, submitting } = props;
   const dispatch = useDispatch();
 
-  useEffect(() => {
-    // if statement here to prevent double HTTP requests
-    if (!submitting) {
-      (async () => {
-        let res = await axios.get(`${backendUrl}/FAQ`);
-        dispatch({ type: 'UPDATE_QUESTIONS_DATA', newQuestionsData: res.data })
-      })();
-    }
-  }, [submitting, dispatch]);
+  // useEffect(() => {
+  //   dispatch(reset('QuestionForm'));
+  // }, [successfulSubmit, dispatch]);
 
   return (
     <form onSubmit={handleSubmit} className="QuestionForm">

--- a/src/components/QuestionForm/QuestionForm.jsx
+++ b/src/components/QuestionForm/QuestionForm.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 
 function validate(values)

--- a/src/components/QuestionForm/QuestionForm.jsx
+++ b/src/components/QuestionForm/QuestionForm.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import { Field, reduxForm } from 'redux-form';
 
 function validate(values)
@@ -30,11 +29,6 @@ function renderField({ input, type, label, meta: { touched, error, warning } }) 
 
 function QuestionForm(props) {
   const { handleSubmit, pristine, submitting } = props;
-  const dispatch = useDispatch();
-
-  // useEffect(() => {
-  //   dispatch(reset('QuestionForm'));
-  // }, [successfulSubmit, dispatch]);
 
   return (
     <form onSubmit={handleSubmit} className="QuestionForm">

--- a/src/components/QuestionsContainer.jsx
+++ b/src/components/QuestionsContainer.jsx
@@ -1,10 +1,27 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import Question from './Question';
 import './QuestionsContainer.css'
+import axios from 'axios';
+
+const backendUrl = process.env.REACT_APP_BACKEND_URL;
 
 function QuestionsContainer() {
   const questionsData = useSelector((state) => state.questionsReducer.questionsData);
+  const successfulSubmit = useSelector((state) => state.adminDashReducer.successfulSubmit);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    async function refreshData() {
+      if (successfulSubmit) {
+        let res = await axios.get(`${backendUrl}/FAQ`);
+        dispatch({ type: 'UPDATE_QUESTIONS_DATA', newQuestionsData: res.data });
+        dispatch({ type: 'NO_SUCCESSFUL_SUBMIT' });
+      }
+    }
+
+    refreshData();
+  }, [successfulSubmit, dispatch]);
 
   return (
     <section className="QuestionsContainer">

--- a/src/components/QuestionsContainer.jsx
+++ b/src/components/QuestionsContainer.jsx
@@ -1,27 +1,10 @@
-import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import Question from './Question';
 import './QuestionsContainer.css'
-import axios from 'axios';
-
-const backendUrl = process.env.REACT_APP_BACKEND_URL;
 
 function QuestionsContainer() {
   const questionsData = useSelector((state) => state.questionsReducer.questionsData);
-  const successfulSubmit = useSelector((state) => state.adminDashReducer.successfulSubmit);
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    async function refreshData() {
-      if (successfulSubmit) {
-        let res = await axios.get(`${backendUrl}/FAQ`);
-        dispatch({ type: 'UPDATE_QUESTIONS_DATA', newQuestionsData: res.data });
-        dispatch({ type: 'NO_SUCCESSFUL_SUBMIT' });
-      }
-    }
-
-    refreshData();
-  }, [successfulSubmit, dispatch]);
 
   return (
     <section className="QuestionsContainer">

--- a/src/components/Work.jsx
+++ b/src/components/Work.jsx
@@ -4,7 +4,7 @@ import BtnDeleteDoc from './BtnDeleteDoc';
 
 function Work(props) {
   const onAdminDash = useSelector((state) => state.adminDashReducer.onAdminDash);
-  const { id, imageUrl } = props;
+  const { id, imageUrl, category } = props;
   const collection = 'portfolio';
 
   return (
@@ -16,6 +16,7 @@ function Work(props) {
           <BtnDeleteDoc
             collection={collection}
             id={id}
+            category={category}
           />
         </div> :
         null

--- a/src/components/WorkForm/WorkForm.jsx
+++ b/src/components/WorkForm/WorkForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { Field, reduxForm } from 'redux-form';
 import AttachmentField from '../AttachmentField';
 import DropdownListField from '../DropdownListField';
@@ -20,13 +21,14 @@ function validate(values) {
 }
 
 const categories = [
-  { category: 'Bridal', value: 'bridal' },
   { category: 'Beauty', value: 'beauty' },
+  { category: 'Bridal', value: 'bridal' },
   { category: 'Editorial', value: 'editorial' }
 ]
 
 function WorkForm(props) {
-  const { handleSubmit, pristine, submitting, success, setSuccess } = props;
+  const { handleSubmit, pristine, submitting } = props;
+  const successfulSubmit = useSelector((state) => state.adminDashReducer.successfulSubmit);
   // this state is needed outside of the AttachmentField to avoid component unmounted errors from react-dropzone when using redux-form validations, do not move into AttachmentField
   const [files, setFiles] = useState([]);
 
@@ -56,8 +58,6 @@ function WorkForm(props) {
             input={input}
             files={files}
             setFiles={setFiles}
-            success={success}
-            setSuccess={setSuccess}
           />
           {touched && ((error && <span>{error}</span>) || (warning && <span>{warning}</span>))}
         </div>
@@ -66,7 +66,7 @@ function WorkForm(props) {
   }
 
   useEffect(() => {
-    if (success) {
+    if (successfulSubmit) {
       setFiles([]);
     }
     // Make sure to revoke the data uris to avoid memory leaks
@@ -74,7 +74,7 @@ function WorkForm(props) {
       files.forEach((file) => URL.revokeObjectURL(file.preview));
     }
   // react warning asks to put files as a dependency, but this results in the app and browser crashing, so for now ignore that warning. only add files as dependency if a refactoring of files and this useEffect is somehow achieved.
-  }, [success]);
+  }, [successfulSubmit]);
 
   return (
     <form className="WorkForm" onSubmit={handleSubmit}>

--- a/src/pages/AdminPage/AdminPage.jsx
+++ b/src/pages/AdminPage/AdminPage.jsx
@@ -51,6 +51,7 @@ function AdminPage() {
       let res = await axios.get(`${backendUrl}/portfolio`);
       dispatch({ type: 'UPDATE_PORTFOLIO_DATA', newPortfolioData: res.data });
       dispatch({ type: `${category.toUpperCase()}_PORTFOLIO_DATA` });
+      dispatch({ type: 'SUCCESSFUL_SUBMIT' });
     } catch (err) {
       console.log(err);
     }

--- a/src/pages/AdminPage/AdminPage.jsx
+++ b/src/pages/AdminPage/AdminPage.jsx
@@ -48,7 +48,8 @@ function AdminPage() {
         await axios.post(`${backendUrl}/portfolio`, params);
       }
 
-      // setSuccess(true);
+      let res = await axios.get(`${backendUrl}/portfolio`);
+      dispatch({ type: 'UPDATE_PORTFOLIO_DATA', newPortfolioData: res.data });
     } catch (err) {
       console.log(err);
     }
@@ -61,7 +62,8 @@ function AdminPage() {
 
     try {
       await axios.post(`${backendUrl}/FAQ`, params);
-      dispatch({ type: 'SUCCESSFUL_SUBMIT' });
+      let res = await axios.get(`${backendUrl}/FAQ`);
+      dispatch({ type: 'UPDATE_QUESTIONS_DATA', newQuestionsData: res.data });
       dispatch(reset('QuestionForm'));
     } catch (err) {
       console.log(err);
@@ -77,12 +79,10 @@ function AdminPage() {
   return (
     <div className="AdminPage" data-testid="AdminPage">
       <h1>Admin Dashboard</h1>
-      {/* <WorkForm
+      <WorkForm
         onSubmit={handlePortfolioSubmit}
-        success={success}
-        setSuccess={setSuccess}
       />
-      <PortfolioContainer /> */}
+      <PortfolioContainer />
       <QuestionForm
         onSubmit={handleQuestionsSubmit}
       />

--- a/src/pages/AdminPage/AdminPage.jsx
+++ b/src/pages/AdminPage/AdminPage.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import axios from 'axios';
 import { useSelector, useDispatch } from 'react-redux';
+import { reset } from 'redux-form';
 import PortfolioContainer from '../../components/PortfolioContainer';
 import WorkForm from '../../components/WorkForm/WorkForm';
 import QuestionsContainer from '../../components/QuestionsContainer';
@@ -12,7 +13,6 @@ function AdminPage() {
   const workForm = useSelector((state) => state.form.WorkForm);
   const questionForm = useSelector((state) => state.form.QuestionForm);
   const dispatch = useDispatch();
-  const [success, setSuccess] = useState(false);
 
   async function handlePortfolioSubmit() {
     let { category, imageBlobs } = workForm.values;
@@ -48,7 +48,7 @@ function AdminPage() {
         await axios.post(`${backendUrl}/portfolio`, params);
       }
 
-      setSuccess(true);
+      // setSuccess(true);
     } catch (err) {
       console.log(err);
     }
@@ -61,33 +61,28 @@ function AdminPage() {
 
     try {
       await axios.post(`${backendUrl}/FAQ`, params);
+      dispatch({ type: 'SUCCESSFUL_SUBMIT' });
+      dispatch(reset('QuestionForm'));
     } catch (err) {
       console.log(err);
     }
   }
 
   useEffect(() => {
-    dispatch({type: "UPDATE_ON_ADMIN_DASH", newOnAdminDash: true});
+    dispatch({ type: 'UPDATE_ON_ADMIN_DASH', newOnAdminDash: true });
 
-    return () => dispatch({ type: "UPDATE_ON_ADMIN_DASH", newOnAdminDash: false });
-  }, [dispatch])
-
-  useEffect(() => {
-    (async () => {
-      let res = await axios.get(`${backendUrl}/portfolio`);
-      dispatch({ type: 'UPDATE_PORTFOLIO_DATA', newPortfolioData: res.data })
-    })();
-  }, [success, dispatch]);
+    return () => dispatch({ type: 'UPDATE_ON_ADMIN_DASH', newOnAdminDash: false });
+  }, [dispatch]);
 
   return (
     <div className="AdminPage" data-testid="AdminPage">
       <h1>Admin Dashboard</h1>
-      <WorkForm
+      {/* <WorkForm
         onSubmit={handlePortfolioSubmit}
         success={success}
         setSuccess={setSuccess}
       />
-      <PortfolioContainer />
+      <PortfolioContainer /> */}
       <QuestionForm
         onSubmit={handleQuestionsSubmit}
       />

--- a/src/pages/AdminPage/AdminPage.jsx
+++ b/src/pages/AdminPage/AdminPage.jsx
@@ -50,6 +50,7 @@ function AdminPage() {
 
       let res = await axios.get(`${backendUrl}/portfolio`);
       dispatch({ type: 'UPDATE_PORTFOLIO_DATA', newPortfolioData: res.data });
+      dispatch({ type: `${category.toUpperCase()}_PORTFOLIO_DATA` });
     } catch (err) {
       console.log(err);
     }
@@ -61,8 +62,8 @@ function AdminPage() {
     let params = { question, answer };
 
     try {
-      await axios.post(`${backendUrl}/FAQ`, params);
-      let res = await axios.get(`${backendUrl}/FAQ`);
+      await axios.post(`${backendUrl}/questions`, params);
+      let res = await axios.get(`${backendUrl}/questions`);
       dispatch({ type: 'UPDATE_QUESTIONS_DATA', newQuestionsData: res.data });
       dispatch(reset('QuestionForm'));
     } catch (err) {

--- a/src/reducers/adminDashReducer.js
+++ b/src/reducers/adminDashReducer.js
@@ -1,5 +1,6 @@
 const initialState = {
-  onAdminDash: false
+  onAdminDash: false,
+  successfulSubmit: false
 };
 
 function adminDashReducer(state = initialState, action) {
@@ -8,6 +9,12 @@ function adminDashReducer(state = initialState, action) {
   switch(action.type) {
     case 'UPDATE_ON_ADMIN_DASH':
       newState = { ...state, onAdminDash: action.newOnAdminDash };
+      break;
+    case 'SUCCESSFUL_SUBMIT':
+      newState = { ...state, successfulSubmit: true };
+      break;
+    case 'NO_SUCCESSFUL_SUBMIT':
+      newState = { ...state, successfulSubmit: false };
       break;
     default:
       newState = { ...state };

--- a/src/reducers/portfolioReducer.js
+++ b/src/reducers/portfolioReducer.js
@@ -11,22 +11,22 @@ function portfolioReducer(state = initialState, action) {
       newState = { ...state, portfolioData: action.newPortfolioData };
       break;
     case 'BRIDAL_PORTFOLIO_DATA':
-        const filterBridal = state.portfolioData.filter(image => {
-          return image.category === 'bridal';
-        })
-        newState = { ...state, filteredPortfolioData: filterBridal };
+      const filterBridal = state.portfolioData.filter((image) => {
+        return image.category === 'bridal';
+      })
+      newState = { ...state, filteredPortfolioData: filterBridal };
       break;
     case 'BEAUTY_PORTFOLIO_DATA':
-        const filterBeauty = state.portfolioData.filter(image => {
-          return image.category === 'beauty';
-        })
-        newState = { ...state, filteredPortfolioData: filterBeauty };
+      const filterBeauty = state.portfolioData.filter((image) => {
+        return image.category === 'beauty';
+      })
+      newState = { ...state, filteredPortfolioData: filterBeauty };
       break;
     case 'EDITORIAL_PORTFOLIO_DATA':
-        const filterEditorial = state.portfolioData.filter(image => {
-          return image.category === 'editorial';
-        })
-        newState = { ...state, filteredPortfolioData: filterEditorial };
+      const filterEditorial = state.portfolioData.filter((image) => {
+        return image.category === 'editorial';
+      })
+      newState = { ...state, filteredPortfolioData: filterEditorial };
       break;
     default:
       newState = { ...state };

--- a/src/reducers/questionsReducer.js
+++ b/src/reducers/questionsReducer.js
@@ -12,7 +12,7 @@ function questionsReducer(state = initialState, action) {
     default:
       newState = { ...state };
   }
-
+  
   return newState;
 }
 


### PR DESCRIPTION
removed a lot of technical debt in regards to the way for submission state was being used, made things way simpler and cut back in regards to managing this state and updating data states as a result of form submission and CRUD buttons.

now both portfolio and questions container components now rerender whenever their respective form submit or CRUD button delete happens, including on a a filtered portfolio container